### PR TITLE
Add redirect to full BC checkout

### DIFF
--- a/pages/cart/index.js
+++ b/pages/cart/index.js
@@ -47,6 +47,10 @@ export default function Index({ allPages, allProducts, homepageContent }) {
   const { updateCart, updatingCart, error } = useUpdateCart()
   const cart = keysToCamel(data?.cart) || []
 
+  const onCheckout = () => {
+    window.location.href = cart.redirectUrls.checkoutUrl
+  }
+
   const onUpdate = (method, itemId, newItem) => {
     updateCart({
       product: { 
@@ -71,6 +75,7 @@ export default function Index({ allPages, allProducts, homepageContent }) {
         </Container>
         <Container>
           <Cart.Provider
+              onCheckout={onCheckout}
               onUpdate={onUpdate}
               cart={cart}
               styles={cartStyles}


### PR DESCRIPTION
Uses the onCheckout prop to handle redirecting to BC's checkout when the button is pressed within the cart component.